### PR TITLE
feat(backend): replace bigram predictions with Claude Haiku streaming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@
 
 6. **Push and open a PR** — push the branch and create a GitHub PR with a clear summary and test plan.
 
+## Backlog
+
+Any feature or improvement that is out of scope for the current task must be captured as a GitHub issue before moving on. Do not add TODO comments in code — open an issue instead.
+
 ## Permissions
 
 - Planning mode approval is required before implementation begins.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,5 +7,6 @@ requests>=2.31.0
 setuptools>=70.0.0
 wheel>=0.45.0
 setuptools<81
+anthropic>=0.28.0
 pytest>=8.0.0
 pytest-asyncio>=0.24.0

--- a/backend/routes/routes.py
+++ b/backend/routes/routes.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 
 import numpy as np
 import socketio
+from anthropic import AsyncAnthropic
 from faster_whisper import WhisperModel
 from fastapi import APIRouter
 
@@ -31,6 +32,11 @@ MAX_TRANSCRIPT_HISTORY = 8
 DEFAULT_PREDICTION_COUNT = 5
 SILENCE_RMS_THRESHOLD = 0.01  # float32 normalized; ~-40 dBFS
 
+_ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+_anthropic_client: Optional[AsyncAnthropic] = (
+    AsyncAnthropic(api_key=_ANTHROPIC_API_KEY) if _ANTHROPIC_API_KEY else None
+)
+
 
 class SessionState:
     def __init__(self) -> None:
@@ -46,6 +52,7 @@ class SessionState:
         self.last_audio_received_ms: Optional[int] = None
         self.last_client_sent_at_ms: Optional[int] = None
         self.last_batch_id: Optional[int] = None
+        self.prediction_task: Optional[asyncio.Task] = None
 
 
 sessions: Dict[str, SessionState] = {}
@@ -86,7 +93,7 @@ def is_silent(samples: np.ndarray, threshold: float = SILENCE_RMS_THRESHOLD) -> 
     return float(np.sqrt(np.mean(samples ** 2))) < threshold
 
 
-def generate_predictions(context: str, transcript_text: str, count: int) -> List[str]:
+def _bigram_fallback(context: str, transcript_text: str, count: int) -> List[str]:
     text = transcript_text.strip().lower()
     words = [w.strip(".,!?;:()[]{}\"'") for w in text.split() if w.strip(".,!?;:()[]{}\"'")]
     if not words:
@@ -120,6 +127,57 @@ def generate_predictions(context: str, transcript_text: str, count: int) -> List
     return result
 
 
+async def stream_llm_prediction(sid: str, context: str, transcript_text: str) -> None:
+    """
+    Fire-and-forget coroutine. Streams a 4-8 word phrase from Claude Haiku,
+    emitting progressive `predictions` updates as tokens arrive.
+    Falls back to bigram predictions silently on any failure or missing key.
+    """
+    if _anthropic_client is None:
+        fallback = _bigram_fallback(context, transcript_text, 1)
+        await sio.emit("predictions", {"items": fallback}, room=sid)
+        return
+
+    system_prompt = (
+        "You are a real-time speech assistant helping a speaker recover their train of "
+        "thought mid-sentence. Given the speaker's preparation notes (context) and what "
+        "they have said so far (transcript), complete their next thought with a natural, "
+        "fluent phrase of exactly 4 to 8 words. Output ONLY the phrase — no punctuation, "
+        "no explanation, no quotation marks."
+    )
+    user_message = (
+        f"Context (speaker's notes):\n{context or '(none)'}\n\n"
+        f"Transcript so far:\n{transcript_text or '(none)'}\n\n"
+        "Continue the speaker's next phrase (4-8 words):"
+    )
+
+    accumulated = ""
+    try:
+        async with _anthropic_client.messages.stream(
+            model="claude-haiku-4-5",
+            max_tokens=24,
+            temperature=0.4,
+            system=system_prompt,
+            messages=[{"role": "user", "content": user_message}],
+        ) as stream:
+            async for text_delta in stream.text_stream:
+                accumulated = (accumulated + text_delta).strip()
+                if accumulated:
+                    await sio.emit("predictions", {"items": [accumulated]}, room=sid)
+
+        if not accumulated:
+            fallback = _bigram_fallback(context, transcript_text, 1)
+            if fallback:
+                await sio.emit("predictions", {"items": fallback}, room=sid)
+
+    except asyncio.CancelledError:
+        raise  # let cancellation propagate cleanly
+    except Exception:
+        fallback = _bigram_fallback(context, transcript_text, 1)
+        if fallback:
+            await sio.emit("predictions", {"items": fallback}, room=sid)
+
+
 @router.get("/")
 async def home() -> str:
     return "Teleprompt backend is running"
@@ -133,7 +191,9 @@ async def connect(sid, environ):
 
 @sio.event
 async def disconnect(sid):
-    sessions.pop(sid, None)
+    state = sessions.pop(sid, None)
+    if state and state.prediction_task and not state.prediction_task.done():
+        state.prediction_task.cancel()
 
 
 @sio.event
@@ -241,12 +301,13 @@ async def audio_pcm(sid, data: bytes):
                     },
                     room=sid,
                 )
-                predictions = generate_predictions(
-                    context=state.context,
-                    transcript_text=state.full_transcript,
-                    count=state.prediction_count,
+
+                # Cancel stale prediction and stream a new one non-blocking
+                if state.prediction_task and not state.prediction_task.done():
+                    state.prediction_task.cancel()
+                state.prediction_task = asyncio.create_task(
+                    stream_llm_prediction(sid, state.context, state.full_transcript)
                 )
-                await sio.emit("predictions", {"items": predictions}, room=sid)
 
             total_ms = (time.perf_counter() - total_start) * 1000.0
             buffered_seconds = len(state.active_buffer) / SAMPLE_RATE

--- a/backend/tests/test_audio_pipeline.py
+++ b/backend/tests/test_audio_pipeline.py
@@ -3,6 +3,7 @@ Tests for the audio_pcm handler: buffering, inference gating,
 buffer trimming, and error recovery.
 """
 
+import asyncio
 import math
 import sys
 import types
@@ -185,22 +186,47 @@ async def test_transcription_event_payload_has_expected_keys(sid):
 
 
 @pytest.mark.asyncio
-async def test_predictions_event_emitted_after_transcription(sid):
-    """A predictions event follows every transcription event."""
+async def test_predictions_task_scheduled_after_transcription(sid):
+    """A prediction task is scheduled (non-blocking) after a transcription fires."""
     model = mock_model_with("one two three")
-    emitted_events = []
 
-    async def capture_emit(event, data, **_):
-        emitted_events.append(event)
+    mock_stream_llm = AsyncMock()
 
     with (
         patch("routes.routes.get_model", new=AsyncMock(return_value=model)),
+        patch("routes.routes.stream_llm_prediction", mock_stream_llm),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = AsyncMock()
+        await audio_pcm(sid, make_pcm(speech(9000)))
+        await asyncio.sleep(0)  # let the event loop run the created task
+
+    mock_stream_llm.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_transcription_emitted_before_prediction_task(sid):
+    """transcription event is emitted before the prediction task fires."""
+    import asyncio as _asyncio
+    model = mock_model_with("hello world")
+    order = []
+
+    async def capture_emit(event, data, **_):
+        order.append(event)
+
+    async def fake_stream(*_, **__):
+        order.append("predictions")
+
+    with (
+        patch("routes.routes.get_model", new=AsyncMock(return_value=model)),
+        patch("routes.routes.stream_llm_prediction", fake_stream),
         patch("routes.routes.sio") as mock_sio,
     ):
         mock_sio.emit = capture_emit
         await audio_pcm(sid, make_pcm(speech(9000)))
+        await _asyncio.sleep(0)
 
-    assert "predictions" in emitted_events
+    assert order.index("transcription") < order.index("predictions")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_generate_predictions.py
+++ b/backend/tests/test_generate_predictions.py
@@ -10,10 +10,10 @@ if "faster_whisper" not in sys.modules:
     fw.WhisperModel = object  # type: ignore[attr-defined]
     sys.modules["faster_whisper"] = fw
 
-from routes.routes import generate_predictions
+from routes.routes import _bigram_fallback as generate_predictions
 
 
-class TestGeneratePredictions:
+class TestBigramFallback:
     # ------------------------------------------------------------------
     # Count enforcement
     # ------------------------------------------------------------------

--- a/backend/tests/test_llm_predictions.py
+++ b/backend/tests/test_llm_predictions.py
@@ -1,0 +1,234 @@
+"""
+Tests for stream_llm_prediction() — Claude Haiku 3.5 streaming phrase completion.
+
+Covers:
+  1. Progressive streaming emits growing phrases to sio.emit
+  2. Falls back to bigram when _anthropic_client is None (no API key)
+  3. Falls back silently on API error
+  4. Falls back on empty/whitespace stream response
+  5. In-flight task is cancelled when a new transcription fires
+"""
+
+import asyncio
+import sys
+import types
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub faster_whisper so routes.py imports cleanly without the model installed
+# ---------------------------------------------------------------------------
+if "faster_whisper" not in sys.modules:
+    fw = types.ModuleType("faster_whisper")
+    fw.WhisperModel = MagicMock  # type: ignore[attr-defined]
+    sys.modules["faster_whisper"] = fw
+
+import routes.routes as routes_module
+from routes.routes import SessionState, sessions, stream_llm_prediction
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_async_text_stream(tokens: list[str]):
+    """Return an async iterator that yields the given token strings."""
+    async def _gen():
+        for t in tokens:
+            yield t
+    return _gen()
+
+
+def make_stream_ctx(tokens: list[str]):
+    """
+    Build a mock async context manager that exposes a .text_stream async iterator,
+    matching the anthropic SDK's `client.messages.stream(...)` interface.
+    """
+    @asynccontextmanager
+    async def _ctx():
+        mock_stream = MagicMock()
+        mock_stream.text_stream = make_async_text_stream(tokens)
+        yield mock_stream
+    return _ctx()
+
+
+@pytest.fixture
+def sid():
+    _sid = "llm-test-sid-001"
+    sessions[_sid] = SessionState()
+    yield _sid
+    sessions.pop(_sid, None)
+
+
+# ---------------------------------------------------------------------------
+# 1. Progressive streaming emits growing phrases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_streaming_emits_progressive_phrases(sid):
+    tokens = ["think", " about", " the", " key", " points"]
+    emitted = []
+
+    async def capture(event, data, **_):
+        if event == "predictions":
+            emitted.append(data["items"][0])
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(return_value=make_stream_ctx(tokens))
+
+    with (
+        patch.object(routes_module, "_anthropic_client", mock_client),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = capture
+        await stream_llm_prediction(sid, "tech talk", "I want to")
+
+    # Each emit should be a prefix of the next
+    assert len(emitted) == len(tokens)
+    assert emitted[0] == "think"
+    assert emitted[-1] == "think about the key points"
+    for i in range(1, len(emitted)):
+        assert emitted[i].startswith(emitted[i - 1].rstrip())
+
+
+# ---------------------------------------------------------------------------
+# 2. Falls back to bigram when no API key (_anthropic_client is None)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_falls_back_when_no_api_key(sid):
+    emitted = []
+
+    async def capture(event, data, **_):
+        if event == "predictions":
+            emitted.append(data["items"])
+
+    with (
+        patch.object(routes_module, "_anthropic_client", None),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = capture
+        await stream_llm_prediction(sid, "context", "some transcript words here")
+
+    assert len(emitted) == 1
+    assert isinstance(emitted[0], list)
+    assert len(emitted[0]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Falls back silently on API error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_falls_back_on_api_error(sid):
+    emitted_events = []
+
+    async def capture(event, data, **_):
+        emitted_events.append(event)
+
+    @asynccontextmanager
+    async def raising_ctx():
+        raise RuntimeError("connection refused")
+        yield  # noqa: unreachable
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(return_value=raising_ctx())
+
+    with (
+        patch.object(routes_module, "_anthropic_client", mock_client),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = capture
+        # Must not raise
+        await stream_llm_prediction(sid, "context", "some transcript")
+
+    assert "predictions" in emitted_events
+
+
+# ---------------------------------------------------------------------------
+# 4. Falls back on empty/whitespace stream response
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_falls_back_on_empty_stream(sid):
+    emitted = []
+
+    async def capture(event, data, **_):
+        if event == "predictions":
+            emitted.append(data["items"])
+
+    mock_client = MagicMock()
+    # Stream yields only whitespace tokens
+    mock_client.messages.stream = MagicMock(return_value=make_stream_ctx(["   ", "  "]))
+
+    with (
+        patch.object(routes_module, "_anthropic_client", mock_client),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = capture
+        await stream_llm_prediction(sid, "context", "some transcript words here")
+
+    # Bigram fallback should have fired
+    assert len(emitted) >= 1
+    assert len(emitted[-1]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 5. In-flight task is cancelled when a new transcription fires
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_previous_prediction_task_cancelled_on_new_transcription(sid):
+    from routes.routes import audio_pcm
+    import math
+    import numpy as np
+
+    SAMPLE_RATE = 16000
+
+    def speech_pcm(n: int = 9000) -> bytes:
+        t = np.linspace(0, n / SAMPLE_RATE, n, endpoint=False)
+        samples = (np.sin(2 * math.pi * 440 * t) * 0.5).astype(np.float32)
+        return (samples * 32767).astype(np.int16).tobytes()
+
+    # Slow stream that won't finish before second audio_pcm call
+    async def slow_text_stream():
+        await asyncio.sleep(10)  # effectively never finishes in test
+        yield "word"
+
+    @asynccontextmanager
+    async def slow_ctx():
+        mock_stream = MagicMock()
+        mock_stream.text_stream = slow_text_stream()
+        yield mock_stream
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(return_value=slow_ctx())
+
+    fake_segment = MagicMock()
+    fake_segment.text = "hello world"
+    mock_model = MagicMock()
+    mock_model.transcribe = MagicMock(return_value=([fake_segment], MagicMock()))
+
+    with (
+        patch.object(routes_module, "_anthropic_client", mock_client),
+        patch("routes.routes.get_model", new=AsyncMock(return_value=mock_model)),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = AsyncMock()
+
+        # First audio chunk — starts a prediction task
+        await audio_pcm(sid, speech_pcm())
+        first_task = sessions[sid].prediction_task
+        assert first_task is not None
+
+        # Second audio chunk — should cancel the first task
+        await audio_pcm(sid, speech_pcm())
+        second_task = sessions[sid].prediction_task
+
+        # Give the event loop a tick to process cancellation
+        await asyncio.sleep(0)
+
+        assert first_task.cancelled() or first_task.done()
+        assert second_task is not first_task


### PR DESCRIPTION
## Summary
- Replaces the static bigram word model with **Claude Haiku 3.5 streaming** for natural phrase completions
- Predictions stream token-by-token via the existing `predictions` Socket.IO event — frontend unchanged
- In-flight prediction task is cancelled and replaced whenever a new transcription fires, keeping suggestions current
- Silent fallback to bigram model if `ANTHROPIC_API_KEY` is unset or any API error occurs
- Backlog items captured as GitHub issues #25 and #26

## How it works
1. After Whisper emits a `transcription` event, `asyncio.create_task` schedules `stream_llm_prediction` non-blocking
2. Claude Haiku receives the speaker's context (notes/outline) + full transcript and streams a 4-8 word continuation
3. Each token accumulates and emits `{"items": [growing_phrase]}` — the frontend sees a typewriter-like phrase build up
4. On disconnect, the in-flight task is cancelled cleanly

## Setup
Add to `backend/.env`:
```
ANTHROPIC_API_KEY=sk-ant-...
```

## Test plan
- [ ] `cd backend && source env/bin/activate && python -m pytest tests/ -v` → 65 passed
- [ ] Set `ANTHROPIC_API_KEY` in `.env`, start backend + frontend, speak a sentence — prediction phrase streams in progressively
- [ ] Stay silent — silence gate blocks API calls, no spurious predictions
- [ ] Unset `ANTHROPIC_API_KEY`, restart backend — bigram fallback activates, no errors surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)