### PR TITLE
feat: only trigger prediction when Claude is free and new words arrived

### DIFF
--- a/backend/routes/routes.py
+++ b/backend/routes/routes.py
@@ -53,6 +53,7 @@ class SessionState:
         self.last_client_sent_at_ms: Optional[int] = None
         self.last_batch_id: Optional[int] = None
         self.prediction_task: Optional[asyncio.Task] = None
+        self.last_predicted_word_count: int = 0
 
 
 sessions: Dict[str, SessionState] = {}
@@ -211,6 +212,7 @@ async def start_session(sid, payload: Dict[str, str]):
 
     state.context = (payload or {}).get("context", "").strip()
     state.full_transcript = ""
+    state.last_predicted_word_count = 0
     prediction_count = (payload or {}).get("predictionCount", DEFAULT_PREDICTION_COUNT)
     try:
         state.prediction_count = max(1, min(int(prediction_count), 10))
@@ -309,12 +311,14 @@ async def audio_pcm(sid, data: bytes):
                     room=sid,
                 )
 
-                # Cancel stale prediction and stream a new one non-blocking
-                if state.prediction_task and not state.prediction_task.done():
-                    state.prediction_task.cancel()
-                state.prediction_task = asyncio.create_task(
-                    stream_llm_prediction(sid, state.context, state.full_transcript)
-                )
+                # Only start a new prediction when Claude is free and new words arrived
+                new_word_count = len(state.full_transcript.split())
+                task_is_free = state.prediction_task is None or state.prediction_task.done()
+                if new_word_count > state.last_predicted_word_count and task_is_free:
+                    state.last_predicted_word_count = new_word_count
+                    state.prediction_task = asyncio.create_task(
+                        stream_llm_prediction(sid, state.context, state.full_transcript)
+                    )
 
             total_ms = (time.perf_counter() - total_start) * 1000.0
             buffered_seconds = len(state.active_buffer) / SAMPLE_RATE

--- a/backend/tests/test_audio_pipeline.py
+++ b/backend/tests/test_audio_pipeline.py
@@ -280,3 +280,92 @@ async def test_dict_payload_with_metadata(sid):
 async def test_dict_payload_missing_pcm_does_not_raise(sid):
     """Dict payload without 'pcm' key is handled gracefully."""
     await audio_pcm(sid, {"client_sent_at_ms": 123})
+
+
+# ---------------------------------------------------------------------------
+# Prediction debounce: finish-then-refresh
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prediction_fires_when_task_is_free_and_new_words(sid):
+    """Prediction task is created when no task is running and new words arrive."""
+    model = mock_model_with("hello world")
+
+    with (
+        patch("routes.routes.get_model", new=AsyncMock(return_value=model)),
+        patch("routes.routes.stream_llm_prediction", AsyncMock()) as mock_llm,
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = AsyncMock()
+        await audio_pcm(sid, make_pcm(speech(9000)))
+        await asyncio.sleep(0)
+
+    mock_llm.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_prediction_does_not_interrupt_running_task(sid):
+    """A running prediction task is NOT cancelled when new words arrive."""
+    model = mock_model_with("hello world")
+
+    running_task = MagicMock()
+    running_task.done.return_value = False
+    running_task.cancel = MagicMock()
+    sessions[sid].prediction_task = running_task
+    sessions[sid].last_predicted_word_count = 0  # new words will arrive
+
+    with (
+        patch("routes.routes.get_model", new=AsyncMock(return_value=model)),
+        patch("routes.routes.stream_llm_prediction", AsyncMock()),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = AsyncMock()
+        await audio_pcm(sid, make_pcm(speech(9000)))
+
+    running_task.cancel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prediction_restarts_when_task_done_and_new_words(sid):
+    """A new prediction fires once the previous task is done and new words arrived."""
+    model = mock_model_with("one two three four")
+
+    done_task = MagicMock()
+    done_task.done.return_value = True
+    sessions[sid].prediction_task = done_task
+    sessions[sid].last_predicted_word_count = 0
+
+    with (
+        patch("routes.routes.get_model", new=AsyncMock(return_value=model)),
+        patch("routes.routes.stream_llm_prediction", AsyncMock()) as mock_llm,
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = AsyncMock()
+        await audio_pcm(sid, make_pcm(speech(9000)))
+        await asyncio.sleep(0)
+
+    mock_llm.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_prediction_does_not_refire_same_word_count(sid):
+    """No new prediction fires when word count hasn't grown since last prediction."""
+    model = mock_model_with("hello world")
+
+    # Simulate: prediction already ran for these exact words
+    sessions[sid].last_predicted_word_count = 2  # "hello world" = 2 words
+
+    done_task = MagicMock()
+    done_task.done.return_value = True
+    sessions[sid].prediction_task = done_task
+
+    with (
+        patch("routes.routes.get_model", new=AsyncMock(return_value=model)),
+        patch("routes.routes.stream_llm_prediction", AsyncMock()) as mock_llm,
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = AsyncMock()
+        await audio_pcm(sid, make_pcm(speech(9000)))
+        await asyncio.sleep(0)
+
+    mock_llm.assert_not_called()

--- a/backend/tests/test_llm_predictions.py
+++ b/backend/tests/test_llm_predictions.py
@@ -176,11 +176,12 @@ async def test_falls_back_on_empty_stream(sid):
 
 
 # ---------------------------------------------------------------------------
-# 5. In-flight task is cancelled when a new transcription fires
+# 5. In-flight task is NOT cancelled when a new transcription fires
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_previous_prediction_task_cancelled_on_new_transcription(sid):
+async def test_running_prediction_task_not_interrupted_on_new_transcription(sid):
+    """A still-running prediction is left alone when new words arrive; no new task is spawned."""
     from routes.routes import audio_pcm
     import math
     import numpy as np
@@ -222,13 +223,14 @@ async def test_previous_prediction_task_cancelled_on_new_transcription(sid):
         await audio_pcm(sid, speech_pcm())
         first_task = sessions[sid].prediction_task
         assert first_task is not None
+        assert not first_task.done()  # still running (slow stream)
 
-        # Second audio chunk — should cancel the first task
+        # Second audio chunk — task is still running, should NOT be replaced
         await audio_pcm(sid, speech_pcm())
         second_task = sessions[sid].prediction_task
 
-        # Give the event loop a tick to process cancellation
         await asyncio.sleep(0)
 
-        assert first_task.cancelled() or first_task.done()
-        assert second_task is not first_task
+        # Same task object — not interrupted, not replaced
+        assert second_task is first_task
+        assert not first_task.cancelled()


### PR DESCRIPTION
## Summary
- Previously, every Whisper pass (every 0.5s) unconditionally cancelled and restarted the Claude prediction task, giving it ~0ms runway to finish
- Now a new prediction only fires when (a) the previous task is done AND (b) the transcript has gained new words
- While Claude is streaming, words keep accumulating — the next prediction fires immediately when Claude finishes, using the latest transcript
- No LIFO parallelism, no wasted API calls, no rate limit risk

## Behaviour change
| Before | After |
|---|---|
| Cancel + restart every 0.5s | Let current prediction complete |
| Claude never finishes | Claude completes, then refreshes |
| Flickering/no visible prediction | Stable phrase, then updates |

## Test plan
- [x] `test_prediction_fires_when_task_is_free_and_new_words` — prediction starts when task is free
- [x] `test_prediction_does_not_interrupt_running_task` — running task is not cancelled
- [x] `test_prediction_restarts_when_task_done_and_new_words` — refreshes immediately after completion
- [x] `test_prediction_does_not_refire_same_word_count` — no redundant API calls
- [x] Updated `test_running_prediction_task_not_interrupted_on_new_transcription` to reflect new design
- [x] Full suite: 71/71 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)