### PR TITLE
feat: tune prediction to 1-3 word nudge with context-scoped prompt

### DIFF
--- a/backend/routes/routes.py
+++ b/backend/routes/routes.py
@@ -130,7 +130,7 @@ def _bigram_fallback(context: str, transcript_text: str, count: int) -> List[str
 
 async def stream_llm_prediction(sid: str, context: str, transcript_text: str) -> None:
     """
-    Fire-and-forget coroutine. Streams a 4-8 word phrase from Claude Haiku,
+    Fire-and-forget coroutine. Streams a 1-3 word nudge from Claude Haiku,
     emitting progressive `predictions` updates as tokens arrive.
     Falls back to bigram predictions silently on any failure or missing key.
     """
@@ -140,23 +140,25 @@ async def stream_llm_prediction(sid: str, context: str, transcript_text: str) ->
         return
 
     system_prompt = (
-        "You are a real-time speech assistant helping a speaker recover their train of "
-        "thought mid-sentence. Given the speaker's preparation notes (context) and what "
-        "they have said so far (transcript), complete their next thought with a natural, "
-        "fluent phrase of exactly 4 to 8 words. Output ONLY the phrase — no punctuation, "
-        "no explanation, no quotation marks."
+        "You are a real-time speech assistant. A speaker has blanked mid-sentence and needs a nudge.\n\n"
+        "Your job: predict the next 1 to 3 words — the minimum needed to get them speaking again. "
+        "Choose the count dynamically: 1 word if the continuation is obvious, up to 3 if more context helps.\n\n"
+        "Scope: treat the speaker's context notes as the domain for the conversation. "
+        "Stay strictly within that domain when predicting. "
+        "If no context is given, infer the topic from the transcript.\n\n"
+        "Output ONLY the words — no punctuation, no explanation, no quotes."
     )
     user_message = (
-        f"Context (speaker's notes):\n{context or '(none)'}\n\n"
-        f"Transcript so far:\n{transcript_text or '(none)'}\n\n"
-        "Continue the speaker's next phrase (4-8 words):"
+        f"Speaker's topic and domain (scope for all predictions):\n{context or '(none)'}\n\n"
+        f"What the speaker has said so far:\n{transcript_text or '(none)'}\n\n"
+        "Next words (1-3):"
     )
 
     accumulated = ""
     try:
         async with _anthropic_client.messages.stream(
             model="claude-haiku-4-5",
-            max_tokens=24,
+            max_tokens=12,
             temperature=0.4,
             system=system_prompt,
             messages=[{"role": "user", "content": user_message}],

--- a/backend/tests/test_llm_predictions.py
+++ b/backend/tests/test_llm_predictions.py
@@ -234,3 +234,67 @@ async def test_running_prediction_task_not_interrupted_on_new_transcription(sid)
         # Same task object — not interrupted, not replaced
         assert second_task is first_task
         assert not first_task.cancelled()
+
+
+# ---------------------------------------------------------------------------
+# 6. Prompt uses "unstuck" framing, context as scope, 1-3 words, max_tokens=12
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prompt_uses_unstuck_framing_and_context_scope(sid):
+    """System prompt frames goal as getting speaker unstuck; context treated as scope."""
+    captured_kwargs = {}
+
+    @asynccontextmanager
+    async def capturing_ctx(**kwargs):
+        captured_kwargs.update(kwargs)
+        mock_stream = MagicMock()
+        mock_stream.text_stream = make_async_text_stream(["next"])
+        yield mock_stream
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(side_effect=lambda **kw: capturing_ctx(**kw))
+
+    with (
+        patch.object(routes_module, "_anthropic_client", mock_client),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = AsyncMock()
+        await stream_llm_prediction(sid, "machine learning seminar", "the key insight is")
+
+    system = captured_kwargs.get("system", "")
+    user_msg = captured_kwargs.get("messages", [{}])[0].get("content", "")
+
+    assert "unstuck" in system.lower() or "blank" in system.lower(), \
+        "system prompt should reference getting the speaker unstuck"
+    assert "1" in system and "3" in system, \
+        "system prompt should specify 1 to 3 words"
+    assert "scope" in system.lower() or "domain" in system.lower(), \
+        "system prompt should reference context as scope/domain"
+    assert "machine learning seminar" in user_msg, \
+        "context should appear in user message"
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_is_twelve(sid):
+    """Claude is called with max_tokens=12 for short phrase predictions."""
+    captured_kwargs = {}
+
+    @asynccontextmanager
+    async def capturing_ctx(**kwargs):
+        captured_kwargs.update(kwargs)
+        mock_stream = MagicMock()
+        mock_stream.text_stream = make_async_text_stream(["go"])
+        yield mock_stream
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(side_effect=lambda **kw: capturing_ctx(**kw))
+
+    with (
+        patch.object(routes_module, "_anthropic_client", mock_client),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = AsyncMock()
+        await stream_llm_prediction(sid, "context", "some transcript")
+
+    assert captured_kwargs.get("max_tokens") == 12


### PR DESCRIPTION
## Summary
- Reframes Claude's role from "complete a phrase (4-8 words)" to "get the speaker unstuck with 1-3 words"
- Claude dynamically chooses the count: 1 word if obvious, up to 3 if context helps
- Context notes are now explicitly treated as the domain scope — predictions stay within that topic
- `max_tokens` reduced from 24 → 12 to match shorter output

## Prompt changes
| Before | After |
|---|---|
| "complete their next thought with a natural, fluent phrase of exactly 4 to 8 words" | "predict the next 1 to 3 words — the minimum needed to get them speaking again" |
| Context labelled as "speaker's notes" | Context labelled as "Speaker's topic and domain (scope for all predictions)" |
| `max_tokens=24` | `max_tokens=12` |

## Test plan
- [x] `test_prompt_uses_unstuck_framing_and_context_scope` — system prompt references blanking/unstuck, 1-3 words, domain scope; context appears in user message
- [x] `test_max_tokens_is_twelve` — Claude called with `max_tokens=12`
- [x] Full suite: 73/73 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)