### PR TITLE
feat: latency profiling for prediction pipeline

### DIFF
--- a/backend/routes/routes.py
+++ b/backend/routes/routes.py
@@ -155,6 +155,8 @@ async def stream_llm_prediction(sid: str, context: str, transcript_text: str) ->
     )
 
     accumulated = ""
+    prediction_start = time.perf_counter()
+    first_token = True
     try:
         async with _anthropic_client.messages.stream(
             model="claude-haiku-4-5",
@@ -166,7 +168,13 @@ async def stream_llm_prediction(sid: str, context: str, transcript_text: str) ->
             async for text_delta in stream.text_stream:
                 accumulated = (accumulated + text_delta).strip()
                 if accumulated:
-                    await sio.emit("predictions", {"items": [accumulated]}, room=sid)
+                    payload = {"items": [accumulated]}
+                    if first_token:
+                        ttft_ms = round((time.perf_counter() - prediction_start) * 1000)
+                        payload["prediction_ms"] = ttft_ms
+                        logger.info("prediction_ttft_ms=%d sid=%s", ttft_ms, sid)
+                        first_token = False
+                    await sio.emit("predictions", payload, room=sid)
 
         if not accumulated:
             fallback = _bigram_fallback(context, transcript_text, 1)

--- a/backend/tests/test_llm_predictions.py
+++ b/backend/tests/test_llm_predictions.py
@@ -298,3 +298,64 @@ async def test_max_tokens_is_twelve(sid):
         await stream_llm_prediction(sid, "context", "some transcript")
 
     assert captured_kwargs.get("max_tokens") == 12
+
+
+# ---------------------------------------------------------------------------
+# WS3: Latency profiling — timing fields in predictions payload
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_first_predictions_event_includes_prediction_ms(sid):
+    """The first predictions event includes a prediction_ms timing field."""
+    tokens = ["next", " step"]
+    first_payload = {}
+
+    async def capture(event, data, **_):
+        if event == "predictions" and not first_payload:
+            first_payload.update(data)
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(return_value=make_stream_ctx(tokens))
+
+    with (
+        patch.object(routes_module, "_anthropic_client", mock_client),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = capture
+        await stream_llm_prediction(sid, "context", "transcript here")
+
+    assert "prediction_ms" in first_payload, (
+        f"prediction_ms missing from first predictions payload: {first_payload}"
+    )
+    assert isinstance(first_payload["prediction_ms"], (int, float))
+    assert first_payload["prediction_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_subsequent_predictions_events_omit_prediction_ms(sid):
+    """Only the first predictions event carries prediction_ms — subsequent ones do not."""
+    tokens = ["a", " b", " c"]
+    all_payloads = []
+
+    async def capture(event, data, **_):
+        if event == "predictions":
+            all_payloads.append(dict(data))
+
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(return_value=make_stream_ctx(tokens))
+
+    with (
+        patch.object(routes_module, "_anthropic_client", mock_client),
+        patch("routes.routes.sio") as mock_sio,
+    ):
+        mock_sio.emit = capture
+        await stream_llm_prediction(sid, "context", "transcript")
+
+    assert len(all_payloads) >= 2, "need at least 2 emit calls to test this"
+    # First has prediction_ms
+    assert "prediction_ms" in all_payloads[0]
+    # Rest do not
+    for payload in all_payloads[1:]:
+        assert "prediction_ms" not in payload, (
+            f"subsequent payload should not have prediction_ms: {payload}"
+        )

--- a/frontend/components/recorder.tsx
+++ b/frontend/components/recorder.tsx
@@ -144,7 +144,10 @@ export default function Recorder({
             },
         );
 
-        newSocket.on("predictions", (response: { items?: string[] }) => {
+        newSocket.on("predictions", (response: { items?: string[]; prediction_ms?: number }) => {
+            if (typeof response?.prediction_ms === "number") {
+                console.info(`[latency] prediction_ttft_ms=${response.prediction_ms}`);
+            }
             onPredictions(response?.items ?? []);
         });
 


### PR DESCRIPTION
## Summary

- Backend instruments `stream_llm_prediction` with `time.perf_counter()` to measure time to first token (TTFT)
- First `predictions` event includes `prediction_ms` field; subsequent events do not
- Backend logs `prediction_ttft_ms=X sid=Y` to the `teleprompt.latency` logger on each first token
- Frontend logs `[latency] prediction_ttft_ms=X` to browser console on receipt
- No user-facing UI changes

## Test plan

- [x] `pytest tests/test_llm_predictions.py -k "prediction_ms"` → 2 passed
- [x] `pytest tests/` → 75 passed (73 existing + 2 new)
- [x] Confirm browser console shows `[latency] prediction_ttft_ms=X` during live session
- [x] Confirm server logs show `prediction_ttft_ms=X sid=Y` entries

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)